### PR TITLE
channel list displays name of game creator

### DIFF
--- a/client/components/channelList.js
+++ b/client/components/channelList.js
@@ -17,21 +17,24 @@ const ChannelList = (props) => {
         {
           allBoards && Object.entries(allBoards)
             .filter(board => {
-              return board[1].state.status === 'waiting'
-                && board[1].maxPlayers > board[1].state.playerOrder.length
+              if (board[1].state.playerOrder) {
+                return board[1].state.status === 'waiting'
+                  && board[1].maxPlayers > board[1].state.playerOrder.length
+              }
             })
             .map((board, i) => {
               const boardId = board[0];
               const boardState = board[1];
               const { boardName, maxPlayers } = boardState;
+              const creator = boardState.state.playerOrder[0];
               const currentPlayers = boardState.state.playerOrder;
               const amountOfCurrentPlayers = currentPlayers && Object.keys(currentPlayers).length;
 
               return (
                 <div key={i} className="channel">
-                  <p>{boardId}</p>
-                  <p>{boardName}</p>
-                  <p>players {amountOfCurrentPlayers}/{maxPlayers}</p>
+                  <p>Created by: {creator}</p>
+                  <p>Name: {boardName || 'Untitled'}</p>
+                  <p>Players: {amountOfCurrentPlayers}/{maxPlayers}</p>
                   <button onClick={() => joinGame(boardId, user)}>Join Game</button>
                 </div>
               )


### PR DESCRIPTION
When looking at the channel list, the user now sees the name of the user who created the game instead of the boardId.

I also fixed the bug where, if you create a game and leave the game while in the waiting room, the channel list would no longer display.